### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python"
+run = ""

--- a/README.txt
+++ b/README.txt
@@ -1,6 +1,8 @@
 Interactive GCC
 ===============
 
+[![Run on Repl.it](https://repl.it/badge/github/kgashok/igcc-1)](https://repl.it/github/kgashok/igcc-1)
+
 Interactive GCC (igcc) is a real-eval-print loop (REPL) for C/C++ programmers.
 
 It can be used like this:


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@ashokb/igcc-2).